### PR TITLE
[RFR] Changed the way the renaming works (proposal)

### DIFF
--- a/legofy/__init__.py
+++ b/legofy/__init__.py
@@ -85,8 +85,18 @@ def main(filename, brick=os.path.join(os.path.dirname(__file__), "bricks", "bric
 
     baseImage = Image.open(realPath)
     
-    newFilename = os.path.split(realPath)
-    newFilename = os.path.join(newFilename[0], "lego_{0}".format(newFilename[1]))
+    # Store path (including filename) at 0, extension (including leading dot) at 1
+    chunks = os.path.splitext(realPath)
+
+    # Store extension
+    extension = chunks[1]
+
+    # Store path at 0 (without filename), filename (without extension) at 1
+    chunks = os.path.split(chunks[0])
+
+    # New filename (e.g. path/to/file/filename.lego.ext)
+    newFilename = os.path.join(chunks[0], chunks[1] + '.lego' + extension)
+
 
     scale = 1
     newSize = baseImage.size


### PR DESCRIPTION
This pull-request is only a suggestion, feel free to discard it if you do not agree with the way it works or the even the achieved goal.

So right now, the script renames the file by appending the `lego_` prefix to it, so that `path/to/file.jpg` becomes `path/to/lego_file.jpg`. It works great, except it doesn’t preserve the file order when there are a lot of files in a folder, because of the filename prefix. My proposal would rename the file like so: `path/to/file.lego.jpg`, so that the converted file would live next to the original in the finder (or equivalent file browser).

The code is pretty self explanatory I guess, but I added comments just in case. I am no Python guru, so if anything can be optimised, be sure to tell.

Edit: [I LOVE THIS PROJECT](https://twitter.com/HugoGiraudel/status/661100177227440128)!