### PR TITLE
Use container based travis infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
-before_script:
-- sudo apt-get install imagemagick
+# Use container based infrastructure
+sudo: false
+
+addons:
+  apt:
+    packages:
+    - imagemagick
 language: python
 python:
   - "2.6"

--- a/legofy/cli.py
+++ b/legofy/cli.py
@@ -1,4 +1,4 @@
-import os
+'''Command line interface to Legofy'''
 import click
 import legofy
 
@@ -6,14 +6,15 @@ import legofy
 @click.option('--brick', default=None, type=click.Path(dir_okay=False, exists=True))
 @click.argument('image', required=True)
 @click.argument('output', default=None, required=False)
+
 def main(brick, image, output):
+    '''Main entry point'''
     if brick and output:
         legofy.main(image, brick=brick, output=output)
-    if brick:
+    elif brick:
         legofy.main(image, brick=brick)
-    if output:
+    elif output:
         legofy.main(image, output=output)
-        
 
 if __name__ == '__main__':
     main()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
-from setuptools import setup, find_packages
-
+from setuptools import setup
 
 setup(
     name='legofy',
@@ -21,7 +20,7 @@ setup(
             'legofy = legofy.cli:main',
         ],
     },
-    package_data = {
+    package_data={
         'bricks': ['*.png'],
     },
     test_suite='nose.collector',


### PR DESCRIPTION
This migrates the old test infrastructure to [travis container based tests.](
http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade)
