### PR TITLE
Way too many improvements!

### DIFF
--- a/legofy/__init__.py
+++ b/legofy/__init__.py
@@ -175,7 +175,7 @@ def get_lego_palette(palette_mode):
         palette = palette_mono.values()
     else:
         # All palettes 
-        palette = palette_solid.values() + palette_transparent.values() + palette_effects.values()
+        palette = list(palette_solid.values()) + list(palette_transparent.values()) + list(palette_effects.values())
 
     # Flatten array of color triples
     palette = [item for sublist in palette for item in sublist]
@@ -183,7 +183,7 @@ def get_lego_palette(palette_mode):
     
     # Repeat the first color so that the palette has 256 colors
     first_color = palette[0:3]
-    missing_colors = 256 - len(palette)/3
+    missing_colors = int(256 - len(palette)/3)
     padding = first_color * missing_colors
     palette += padding
     assert len(palette) == 768
@@ -286,4 +286,6 @@ def main(image_path, output_path=None, bricks=None, brick_path=None, palette_mod
         print("Static image detected, will now legofy to {0}".format(output_path))
         legofy_image(base_image, brick_image, output_path, bricks, palette_mode)
 
+    base_image.close()
+    brick_image.close()
     print("Finished!")

--- a/legofy/cli.py
+++ b/legofy/cli.py
@@ -14,7 +14,7 @@ import legofy
 
 def main(image, output, bricks, brick, palette):
     '''Main entry point'''
-    legofy.main(image, output=output, bricks=bricks, brick_path=brick, palette=palette)
+    legofy.main(image, output_path=output, bricks=bricks, brick_path=brick, palette_mode=palette)
 
 if __name__ == '__main__':
     main()

--- a/tests/test_legofy.py
+++ b/tests/test_legofy.py
@@ -5,13 +5,13 @@ import unittest
 
 import legofy
 
+TEST_DIR = os.path.realpath(os.path.dirname(__file__))
 
 class CreateFileTestCase(unittest.TestCase):
     '''Unit tests that create files.'''
 
     def setUp(self):
         self.out_path = None
-        self.test_dir = os.path.realpath(os.path.dirname(__file__))
 
     def tearDown(self):
         if self.out_path:
@@ -27,7 +27,7 @@ class CreateFileTestCase(unittest.TestCase):
     def test_legofy_image(self):
         '''Can we legofy a static image?'''
         self.create_tmpfile('.png')
-        image_path = os.path.join(self.test_dir, '..', 'legofy', 'assets', 'flower.jpg')
+        image_path = os.path.join(TEST_DIR, '..', 'legofy', 'assets', 'flower.jpg')
         self.assertTrue(os.path.exists(image_path),
                         "Could not find image : {0}".format(image_path))
 
@@ -37,7 +37,7 @@ class CreateFileTestCase(unittest.TestCase):
     def test_legofy_gif(self):
         '''Can we legofy a gif?'''
         self.create_tmpfile('.gif')
-        gif_path = os.path.join(self.test_dir, '..', 'legofy', 'assets', 'bacon.gif')
+        gif_path = os.path.join(TEST_DIR, '..', 'legofy', 'assets', 'bacon.gif')
         self.assertTrue(os.path.exists(gif_path),
                         "Could not find image : {0}".format(gif_path))
         legofy.main(gif_path, output_path=self.out_path)
@@ -46,12 +46,21 @@ class CreateFileTestCase(unittest.TestCase):
     def test_legofy_palette(self):
         '''Can we use a palette?'''
         self.create_tmpfile('.png')
-        image_path = os.path.join(self.test_dir, '..', 'legofy', 'assets', 'flower.jpg')
+        image_path = os.path.join(TEST_DIR, '..', 'legofy', 'assets', 'flower.jpg')
         self.assertTrue(os.path.exists(image_path),
                         "Could not find image : {0}".format(image_path))
 
         legofy.main(image_path, output_path=self.out_path, palette_mode='all')
         self.assertTrue(os.path.getsize(self.out_path) > 0)
+
+
+class FailureCases(unittest.TestCase):
+    def test_bad_image_path(self):
+        '''Test invalid image path'''
+        image_path = os.path.join(TEST_DIR, '..', 'legofy', 'assets', 'fake.jpg')
+        self.assertFalse(os.path.exists(image_path),
+                        "Could not find image : {0}".format(image_path))
+        self.assertRaises(SystemExit, legofy.main, image_path)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_legofy.py
+++ b/tests/test_legofy.py
@@ -1,4 +1,6 @@
 '''Unit tests for legofy'''
+# They can be run individually, for example:
+# nosetests tests.test_legofy:Create.test_legofy_image
 import os
 import tempfile
 import unittest
@@ -6,8 +8,9 @@ import unittest
 import legofy
 
 TEST_DIR = os.path.realpath(os.path.dirname(__file__))
+FLOWER_PATH = os.path.join(TEST_DIR, '..', 'legofy', 'assets', 'flower.jpg')
 
-class CreateFileTestCase(unittest.TestCase):
+class Create(unittest.TestCase):
     '''Unit tests that create files.'''
 
     def setUp(self):
@@ -27,11 +30,10 @@ class CreateFileTestCase(unittest.TestCase):
     def test_legofy_image(self):
         '''Can we legofy a static image?'''
         self.create_tmpfile('.png')
-        image_path = os.path.join(TEST_DIR, '..', 'legofy', 'assets', 'flower.jpg')
-        self.assertTrue(os.path.exists(image_path),
-                        "Could not find image : {0}".format(image_path))
+        self.assertTrue(os.path.exists(FLOWER_PATH),
+                        "Could not find image : {0}".format(FLOWER_PATH))
 
-        legofy.main(image_path, output_path=self.out_path)
+        legofy.main(FLOWER_PATH, output_path=self.out_path)
         self.assertTrue(os.path.getsize(self.out_path) > 0)
 
     def test_legofy_gif(self):
@@ -46,21 +48,52 @@ class CreateFileTestCase(unittest.TestCase):
     def test_legofy_palette(self):
         '''Can we use a palette?'''
         self.create_tmpfile('.png')
-        image_path = os.path.join(TEST_DIR, '..', 'legofy', 'assets', 'flower.jpg')
-        self.assertTrue(os.path.exists(image_path),
-                        "Could not find image : {0}".format(image_path))
-
-        legofy.main(image_path, output_path=self.out_path, palette_mode='all')
+        self.assertTrue(os.path.exists(FLOWER_PATH),
+                        "Could not find image : {0}".format(FLOWER_PATH))
+                        
+        legofy.main(FLOWER_PATH, output_path=self.out_path, palette_mode='solid')
+        legofy.main(FLOWER_PATH, output_path=self.out_path, palette_mode='transparent')
+        legofy.main(FLOWER_PATH, output_path=self.out_path, palette_mode='effects')
+        legofy.main(FLOWER_PATH, output_path=self.out_path, palette_mode='mono')
+        legofy.main(FLOWER_PATH, output_path=self.out_path, palette_mode='all')
         self.assertTrue(os.path.getsize(self.out_path) > 0)
+        
+    def test_bricks_parameter(self):
+        self.create_tmpfile('.png')
+        legofy.main(FLOWER_PATH, output_path=self.out_path, bricks=5)
+        size5 = os.path.getsize(self.out_path)
+        legofy.main(FLOWER_PATH, output_path=self.out_path, bricks=10)
+        size10 = os.path.getsize(self.out_path)
+        self.assertTrue(size5 > 0)
+        self.assertTrue(size10 > size5)
+  
+class Functions(unittest.TestCase):
+    '''Test the behaviour of individual functions'''
+    def test_get_new_filename(self):
+        new_path = legofy.get_new_filename(FLOWER_PATH)
+        self.assertTrue(os.path.dirname(FLOWER_PATH) ==
+                        os.path.dirname(new_path))
+        self.assertFalse(os.path.exists(new_path),
+                        "Should not find image : {0}".format(new_path))
+        self.assertTrue(new_path.endswith('_lego.jpg'))
+        new_path = legofy.get_new_filename(FLOWER_PATH, '.gif')
+        self.assertTrue(new_path.endswith('_lego.gif'))
+   
 
-
-class FailureCases(unittest.TestCase):
+class Failures(unittest.TestCase):
+    '''Make sure things fail when they should'''
     def test_bad_image_path(self):
         '''Test invalid image path'''
-        image_path = os.path.join(TEST_DIR, '..', 'legofy', 'assets', 'fake.jpg')
-        self.assertFalse(os.path.exists(image_path),
-                        "Could not find image : {0}".format(image_path))
-        self.assertRaises(SystemExit, legofy.main, image_path)
+        fake_path = os.path.join(TEST_DIR, 'fake_image.jpg')
+        self.assertFalse(os.path.exists(fake_path),
+                        "Should not find image : {0}".format(fake_path))
+        self.assertRaises(SystemExit, legofy.main, fake_path)
+        
+    def test_bad_brick_path(self):
+        fake_path = os.path.join(TEST_DIR, 'fake_brick.jpg')
+        self.assertFalse(os.path.exists(fake_path),
+                        "Should not find image : {0}".format(fake_path))
+        self.assertRaises(SystemExit, legofy.main, FLOWER_PATH, 'im.jpg', 5, fake_path)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_legofy.py
+++ b/tests/test_legofy.py
@@ -31,7 +31,7 @@ class CreateFileTestCase(unittest.TestCase):
         self.assertTrue(os.path.exists(image_path),
                         "Could not find image : {0}".format(image_path))
 
-        legofy.main(image_path, output=self.out_path)
+        legofy.main(image_path, output_path=self.out_path)
         self.assertTrue(os.path.getsize(self.out_path) > 0)
 
     def test_legofy_gif(self):
@@ -40,7 +40,7 @@ class CreateFileTestCase(unittest.TestCase):
         gif_path = os.path.join(self.test_dir, '..', 'legofy', 'assets', 'bacon.gif')
         self.assertTrue(os.path.exists(gif_path),
                         "Could not find image : {0}".format(gif_path))
-        legofy.main(gif_path, output=self.out_path)
+        legofy.main(gif_path, output_path=self.out_path)
         self.assertTrue(os.path.getsize(self.out_path) > 0)
 
     def test_legofy_palette(self):
@@ -50,7 +50,7 @@ class CreateFileTestCase(unittest.TestCase):
         self.assertTrue(os.path.exists(image_path),
                         "Could not find image : {0}".format(image_path))
 
-        legofy.main(image_path, output=self.out_path, palette='all')
+        legofy.main(image_path, output_path=self.out_path, palette_mode='all')
         self.assertTrue(os.path.getsize(self.out_path) > 0)
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Reduce number of arguments to apply_effect() and make_lego_brick()
* Refactor palette code : Correctly build a palette and assert it is valid.
* Separate lego palette generation from palette application.
* Fix dithering argument by using the Image.FLOYDSTEINBERG constant.
* Remove one of the write to disk loops in legofy_loop by keeping the frames in memory.
* Fix possible undefined index variable used for printing the frame number.
* Remove `if` checks before resizing. They were always true.
* Allow windows users to legofy images without image magick.
* Only generate a file name automatically if one is not supplied. Do not modify the supplied one.
* Close image ressources when done. Might not be necessary but was getting errors printed from PIL.
* Add tests to increase coverage.