### PR TITLE
Added brick count statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Options:
   --dither / --no-dither          Use dither algorithm to spread the color approximation error.
   --palette [all|effects|mono|solid|transparent]
                                   Palette to use based on real Lego colors.
-  --help                          Show this message and exit.
+  --help                          Show this message and exit.xxsx
+  --stats                         Shows the count of brick colors
 ```
 
 #### Palette

--- a/legofy/cli.py
+++ b/legofy/cli.py
@@ -17,7 +17,9 @@ from legofy import palettes
 @click.option('--palette', default=None,
               type=click.Choice(palettes.legos().keys()),
               help='Palette to use based on real Lego colors.')
-def main(image, output, size, palette, dither):
+@click.option('--stats/--statistics', default=False,
+              help='Print statistics of brick count with colors.')
+def main(image, output, size, palette, dither, stats):
     '''Legofy an image!'''
     legofy.main(image, output_path=output, size=size,
-                palette_mode=palette, dither=dither)
+                palette_mode=palette, dither=dither, stats=stats)

--- a/legofy/palettes.py
+++ b/legofy/palettes.py
@@ -17,6 +17,59 @@ See README for project details.
 """
 from __future__ import division
 
+LEGOS_LABEL = {
+    'white': {'rgb': (244, 244, 244) },
+    'brick-yellow': {'rgb': (217, 187, 124) },
+    'nougat': {'rgb': (214, 115, 65) },
+    'bright-red': { 'rgb': (222, 1, 14) },
+    'bright-blue': { 'rgb': (1, 88, 168) },
+    'bright-yellow': { 'rgb': (254, 196, 1) },
+    'black': { 'rgb': (2, 2, 2) },
+    'dark-green': { 'rgb': (1, 124, 41) },
+    'bright-green': { 'rgb': (1, 150, 37) },
+    'dark-orange': { 'rgb': (168, 62, 22) },
+    'transparent': { 'rgb': (238, 238, 238) },
+    'transparent-red': { 'rgb': (224, 42, 41) },
+    'transparent-light-blue': { 'rgb': (182, 224, 234) },
+    'transparent-blue': { 'rgb': (80, 177, 232) },
+    'transparent-yellow': { 'rgb': (249, 239, 105) },
+    'transparent-flourescent-reddish-orange': { 'rgb': (231, 102, 72) },
+    'transparent-green': { 'rgb': (99, 178, 110) },
+    'transparent-flourescent-green': { 'rgb': (241, 237, 91) },
+    'medium-blue': { 'rgb': (72, 140, 198) },
+    'bright-orange': { 'rgb': (231, 100, 25) },
+    'transparent-brown': { 'rgb': (166, 145, 130) },
+    'transparent-med-reddish-violet': { 'rgb': (238, 157, 195) },
+    'transparent-yellowish-green': { 'rgb': (149, 185, 12) },
+    'transparent-reddish-violet': { 'rgb': (156, 1, 198) },
+    'transparent-bluish-violet': { 'rgb': (156, 149, 199) },
+    'silver': { 'rgb': (141, 148, 150) },
+    'sand-blue': { 'rgb': (95, 117, 140) },
+    'sand-yellow': { 'rgb': (141, 117, 83) },
+    'earth-blue': { 'rgb': (1, 38, 66) },
+    'earth-green': { 'rgb': (1, 53, 23) },
+    'transparent-flourescent-blue': { 'rgb': (206, 227, 246) },
+    'metallic-dark-grey': { 'rgb': (73, 63, 59) },
+    'sand-green': { 'rgb': (96, 130, 102) },
+    'dark-red': { 'rgb': (128, 9, 28) },
+    'transparent-bright-orange': { 'rgb': (236, 118, 14) },
+    'flame-yellowish-orange': { 'rgb': (244, 155, 1) },
+    'reddish-brown': { 'rgb': (92, 29, 13) },
+    'medium-stone-grey': { 'rgb': (156, 146, 145) },
+    'dark-stone-grey': { 'rgb': (77, 94, 87) },
+    'light-stone-grey': { 'rgb': (228, 228, 218) },
+    'light-royal-blue': { 'rgb': (135, 192, 234) },
+    'bright-purple': { 'rgb': (222, 56, 139) },
+    'light-purple': { 'rgb': (238, 157, 195) },
+    'cool-yellow': { 'rgb': (255, 255, 153) },
+    'medium-lilac': { 'rgb': (45, 22, 120) },
+    'light-nougat': { 'rgb': (245, 193, 137) },
+    'phosph-green': { 'rgb': (254, 252, 213) },
+    'warm-gold': { 'rgb': (170, 127, 46) },
+    'dark-brown': { 'rgb': (49, 16, 7) },
+    'transparent-bright-green': { 'rgb': (153, 255, 102) },
+    'medium-nougat': { 'rgb': (170, 126, 86) }
+}
 
 LEGOS = {
     'solid': {
@@ -98,7 +151,6 @@ def extend_palette(palette, colors=256, rgb=3):
 def legos():
     """Build flattened lego palettes."""
     return _flatten_palettes(LEGOS.copy())
-
 
 def _flatten_palettes(palettes):
     """Convert palette mappings into color list."""


### PR DESCRIPTION
#98 Feature request: displays counts of brick with colors

example: 
legofy --stats --palette all image.jpg
```python
{'transparent-flourescent-blue': 426, 'light-stone-grey': 9, 'transparent-green': 4, 'transparent-bluish-violet': 15, 'transparent-light-blue': 10, 'sand-green': 13, 'silver': 5, 'white': 35, 'dark-stone-grey': 6, 'transparent-brown': 6, 'transparent': 62, 'medium-stone-grey': 309}
```